### PR TITLE
Draft: Automatically recognize national code pages in filenames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ option(ENABLE_ZSTD "Enable use of Zstandard" ON)
 
 option(ENABLE_FDOPEN "Enable zip_fdopen, which is not allowed in Microsoft CRT secure libraries" ON)
 
+if (UNIX)
+    option(ENABLE_LIBNATSPEC "Enable use of libnatspec" ON)
+endif()
+
 option(BUILD_TOOLS "Build tools in the src directory (zipcmp, zipmerge, ziptool)" ON)
 option(BUILD_REGRESS "Build regression tests" ON)
 option(BUILD_OSSFUZZ "Build fuzzers for ossfuzz" ON)
@@ -252,6 +256,15 @@ if(ENABLE_ZSTD)
     message(WARNING "-- zstd library not found; zstandard support disabled")
   endif(zstd_FOUND)
 endif(ENABLE_ZSTD)
+
+if (ENABLE_LIBNATSPEC)
+    find_library(LIBNATSPEC NAMES natspec)
+    if (LIBNATSPEC)
+        set(HAVE_LIBNATSPEC 1)
+    else()
+        message(WARNING "-- libnatspec not found; libnatspec support disabled")
+    endif()
+endif()
 
 if (COMMONCRYPTO_FOUND)
   set(HAVE_CRYPTO 1)

--- a/cmake-config.h.in
+++ b/cmake-config.h.in
@@ -65,6 +65,7 @@
 #cmakedefine HAVE_SYS_NDIR_H
 #cmakedefine WORDS_BIGENDIAN
 #cmakedefine HAVE_SHARED
+#cmakedefine HAVE_LIBNATSPEC
 /* END DEFINES */
 #define PACKAGE "@CMAKE_PROJECT_NAME@"
 #define VERSION "@CMAKE_PROJECT_VERSION@"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -172,6 +172,10 @@ if(HAVE_CRYPTO)
   target_sources(zip PRIVATE zip_winzip_aes.c zip_source_winzip_aes_decode.c zip_source_winzip_aes_encode.c)
 endif()
 
+if (HAVE_LIBNATSPEC)
+    target_link_libraries(zip PRIVATE ${LIBNATSPEC})
+endif()
+
 if(SHARED_LIB_VERSIONNING)
   # MACHO_*_VERSION can be removed when SOVERSION gets increased. Cf #405
   set_target_properties(zip PROPERTIES VERSION 5.5 SOVERSION 5 MACHO_CURRENT_VERSION 6.5 MACHO_COMPATIBILITY_VERSION 6)


### PR DESCRIPTION
Use the natspec library to automatically recognize national code pages
when reading or writing filenames
Introduce ZIP_ENABLE_LIBNATSPEC environment variable to enable it option
(disabled by default)